### PR TITLE
Add Freezer control via MIDI CC 64 and KVO integration

### DIFF
--- a/Going Zero/AppController.mm
+++ b/Going Zero/AppController.mm
@@ -203,6 +203,17 @@
 
 -(void)MIDIDelegateCC:(Byte)cc data:(Byte)data chan:(Byte)chan{
     NSLog(@"MIDI : cc:%d data:%d chan:%d", cc, data, chan+1);
+    
+    // Handle CC 64 (Hold/Sustain pedal) for Freezer control
+    if (cc == 64) {
+        if (data != 0) {
+            // Turn Freezer On (UI will be updated via KVO)
+            [_freezer setActive:YES];
+        } else {
+            // Turn Freezer Off (UI will be updated via KVO)
+            [_freezer setActive:NO];
+        }
+    }
 }
 
 -(void)terminate{

--- a/Going Zero/filter/Freezer.h
+++ b/Going Zero/filter/Freezer.h
@@ -40,6 +40,8 @@ NS_ASSUME_NONNULL_BEGIN
     Boolean _pendingGrainSizeChange;
 }
 
+@property (nonatomic, readonly) BOOL active;
+
 -(void)setActive:(Boolean)active;
 -(void)setGrainSize:(unsigned int)grainSize;
 -(void)processLeft:(float *)leftBuf right:(float *)rightBuf samples:(UInt32)numSamples;

--- a/Going Zero/filter/Freezer.m
+++ b/Going Zero/filter/Freezer.m
@@ -41,13 +41,29 @@
     return self;
 }
 
+-(BOOL)active{
+    // During fade transition, return target state; otherwise return current state
+    if (_isFadingOut || _isFadingIn) {
+        return !_targetBypass;
+    }
+    return !_bypass;
+}
+
 -(void)setActive:(Boolean)active{
     Boolean targetBypass = !active;
     
     // Only start fade transition if state is actually changing and not already fading
     if (targetBypass != _bypass && !_isFadingOut){
+        // Set target state and fade flags BEFORE sending KVO notification
+        // so that active property getter returns new state when observers query it
         _targetBypass = targetBypass;
         _isFadingOut = YES;
+        
+        // Send KVO notification - active property will now return new state
+        [self willChangeValueForKey:@"active"];
+        [self didChangeValueForKey:@"active"];
+        
+        // Start fade transition after KVO notification
         _fadeOutCounter = FADE_SAMPLE_NUM;
         [_fadeOut startFadeOut];
     }

--- a/Going Zero/filter/MiscController.xib
+++ b/Going Zero/filter/MiscController.xib
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="22505" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="24506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22505"/>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="24506"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>


### PR DESCRIPTION
- Implemented handling for MIDI CC 64 to control the Freezer state (on/off).
- Added 'active' property to Freezer for KVO compliance.
- Updated MiscController to observe changes to the Freezer's active state and sync UI accordingly.
- Ensured proper KVO management in MiscController's setFreezer method and dealloc.
- Minor updates to the XIB file for compatibility with the latest tools version.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances Freezer control and state synchronization across MIDI, model, and UI.
> 
> - Map MIDI CC 64 in `AppController.mm` to `_freezer setActive:` (on when data != 0, off when 0)
> - Add readonly `active` to `Freezer`, return target state during fades, and fire KVO notifications before starting fade transitions
> - Update `MiscController` to observe `Freezer.active`, manage observers in `setFreezer`/`dealloc`, sync the Freeze checkbox via `syncUIWithModel`, and propagate UI changes back with `freezeChanged:`
> - Minor XIB metadata/tooling updates
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0bf1cbd7e53c6068f9bb630adb1944518a3794f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->